### PR TITLE
Do not force ruby 2.2.9 on everyone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby "2.2.9"
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,8 +157,5 @@ DEPENDENCIES
   rack-contrib
   rspec
 
-RUBY VERSION
-   ruby 2.2.9p480
-
 BUNDLED WITH
-   1.16.2
+   1.17.2


### PR DESCRIPTION
Hey @rdormer @lubc, 

This PR relaxes the Ruby version. I don't think it is a good idea to force it via the Gemfile.

You may want to use different versions of Ruby.

What do you think? 

