### PR TITLE
Add canonical tag to posts copied to fast ruby

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ category_dir: 'tags'
 excerpt_separator: "<!--more-->"
 author_title_prefix: "Articles by "
 timezone: America/New_York
+fastruby_blog: 'http://www.fastruby.io/blog'
 
 # Details for the RSS feed generator
 url:            'https://www.ombulabs.com'

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ category_dir: 'tags'
 excerpt_separator: "<!--more-->"
 author_title_prefix: "Articles by "
 timezone: America/New_York
-fastruby_blog: 'http://www.fastruby.io/blog'
+fastruby_blog: 'https://www.fastruby.io/blog'
 
 # Details for the RSS feed generator
 url:            'https://www.ombulabs.com'

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,61 +5,62 @@ archive: false
 post_class: post-template
 ---
 
+{% if page.canonical_url %}
+  <link rel="canonical" href="{{ site.fastruby_blog }}{{ page.url }}"/>
+{% endif %}
+
 <main class="content post-layout" role="main">
+  <article class="post">
+    <header class="post-header">
+      <h1 class="post-title">{{ page.title }}</h1>
+      <section class="post-meta">
+        {%- assign post = page -%}
+        {%- include post_meta.html -%}
+      </section>
+    </header>
 
-    <article class="post">
+    <section class="post-content">
+      {{ content }}
+    </section>
 
-        <header class="post-header">
-            <h1 class="post-title">{{ page.title }}</h1>
-            <section class="post-meta">
-              {%- assign post = page -%}
-              {%- include post_meta.html -%}
-            </section>
-        </header>
+    {%- if page.archive -%}
+      <section class="archive">
+        <h5>Archive</h5>
+        <ul>
+          {%- for post in site.posts -%}
+            <li><span>{{ post.date | date_to_string }}</span>  <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
+          {%- endfor -%}
+        </ul>
+      </section>
+    {%- endif -%}
 
-        <section class="post-content">
-          {{ content }}
-        </section>
-
-        {%- if page.archive -%}
-        <section class="archive">
-            <h5>Archive</h5>
-            <ul>
-                {%- for post in site.posts -%}
-                    <li><span>{{ post.date | date_to_string }}</span>  <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
-                {%- endfor -%}
-            </ul>
-        </section>
-        {%- endif -%}
-
-        <footer class="post-footer">
-          {%- if page.author -%}
-            {%- assign author = site.authors[page.author] -%}
-            <figure class="author-image">
-              {%- if author.gravatar -%}
-                <a class="img" href="{{ page.baseurl }}" style="background-image: url(//2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
-                <span class="hidden">{{author.display_name}}'s Picture</span></a>
-              {%- else -%}
-                <a class="img" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
-                <span class="hidden"></span></a>
-              {%- endif -%}
-            </figure>
-            <section class="author">
-              <h4> {{ author.display_name }} </h4>
-              <p>
-                We are the Lean Software Boutique. Check us out at <a href="https://www.ombulabs.com">www.ombulabs.com</a>
-              </p>
-            </section>
+    <footer class="post-footer">
+      {%- if page.author -%}
+        {%- assign author = site.authors[page.author] -%}
+        <figure class="author-image">
+          {%- if author.gravatar -%}
+            <a class="img" href="{{ page.baseurl }}" style="background-image: url(//2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
+            <span class="hidden">{{author.display_name}}'s Picture</span></a>
+          {%- else -%}
+            <a class="img" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
+            <span class="hidden"></span></a>
           {%- endif -%}
+        </figure>
+        <section class="author">
+          <h4> {{ author.display_name }} </h4>
+          <p>
+            We are the Lean Software Boutique. Check us out at <a href="https://www.ombulabs.com">www.ombulabs.com</a>
+          </p>
+        </section>
+      {%- endif -%}
 
-          <!-- Share links section -->
-          {%- include share.html -%}
+      <!-- Share links section -->
+      {%- include share.html -%}
 
-          <!-- Disqus comments -->
-          {%- include disqus.html -%}
+      <!-- Disqus comments -->
+      {%- include disqus.html -%}
 
-        </footer>
-
-    </article>
-    {%- include site_footer.html -%}
+    </footer>
+  </article>
+  {%- include site_footer.html -%}
 </main>

--- a/_posts/2016-07-01-tips-for-upgrading-rails-3-2-to-4.markdown
+++ b/_posts/2016-07-01-tips-for-upgrading-rails-3-2-to-4.markdown
@@ -4,6 +4,7 @@ title: "Tips for upgrading from Rails 3.2 to 4.0"
 date: 2016-07-01 18:37:00
 categories: ["rails"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 There are already quite a few guides in the wild to help with the upgrade of

--- a/_posts/2016-10-11-writing-fast-rails.markdown
+++ b/_posts/2016-10-11-writing-fast-rails.markdown
@@ -4,6 +4,7 @@ title:  "Tips for Writing Fast Rails: Part 1"
 date: 2016-10-11 08:37:00
 categories: ["performance", "rails"]
 author: "etagwerker"
+canonical_url: true
 ---
 
 [Rails](http://rubyonrails.org/) is a powerful framework. You can write a lot of features in a short period of time. In the process you can easily write code that **performs poorly**.

--- a/_posts/2017-08-28-upgrade-to-rails-3.markdown
+++ b/_posts/2017-08-28-upgrade-to-rails-3.markdown
@@ -4,6 +4,7 @@ title:  "Upgrade Rails from 2.3 to 3.0"
 date: 2017-08-28 16:06:00
 categories: ["rails", "upgrades"]
 author: "luciano"
+canonical_url: true
 ---
 
 This article is the first of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org) application from [version 2.3](http://guides.rubyonrails.org/2_3_release_notes.html) to [3.0](http://guides.rubyonrails.org/3_0_release_notes.html).

--- a/_posts/2017-10-16-upgrade-to-rails-3-1.md
+++ b/_posts/2017-10-16-upgrade-to-rails-3-1.md
@@ -4,6 +4,7 @@ title:  "Upgrade Rails from 3.0 to 3.1"
 date: 2017-10-16 09:30:00
 categories: ["rails", "upgrades"]
 author: "luciano"
+canonical_url: true
 ---
 
 This is the second article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.0](http://guides.rubyonrails.org/3_0_release_notes.html) to [3.1](http://guides.rubyonrails.org/3_1_release_notes.html). If you are in an older version, you can take a look at our [previous article](https://www.ombulabs.com/blog/rails/upgrades/upgrade-to-rails-3.html).

--- a/_posts/2017-11-07-upgrade-to-rails-3-2.md
+++ b/_posts/2017-11-07-upgrade-to-rails-3-2.md
@@ -4,6 +4,7 @@ title:  "Upgrade Rails from 3.1 to 3.2"
 date: 2017-11-07 09:30:00
 categories: ["rails", "upgrades"]
 author: "luciano"
+canonical_url: true
 ---
 
 This is the third article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.1](http://guides.rubyonrails.org/3_1_release_notes.html) to [3.2](http://guides.rubyonrails.org/3_2_release_notes.html).

--- a/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
+++ b/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 3.2 to 4.0"
 date: 2017-11-08 12:42:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
+++ b/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 4.0 to 4.1"
 date: 2017-12-06 16:31:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
+++ b/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 4.1 to 4.2"
 date: 2018-02-02 11:32:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-02-14-active-record-5-1-api-changes.markdown
+++ b/_posts/2018-02-14-active-record-5-1-api-changes.markdown
@@ -4,6 +4,7 @@ title: "Cleaning up: ActiveRecord::Dirty 5.2 API Changes"
 date: 2018-02-14 10:20:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 With the release of Rails 5.2 just around the corner

--- a/_posts/2018-02-16-upgrading-a-monolith.markdown
+++ b/_posts/2018-02-16-upgrading-a-monolith.markdown
@@ -4,6 +4,7 @@ title: "Upgrading a Huge Monolith from Rails 4.0 to Rails 5.1"
 date: 2018-02-16
 categories: ["rails", "upgrades", "case-study"]
 author: "emily"
+canonical_url: true
 ---
 
 We recently collaborated with [Power Home Remodeling](https://powerhrg.com) on a [Rails upgrade](https://fastruby.io) for their self-described “monolith CRM/ERP application” and were able to speak to them about their experience with [Ombu Labs](https://www.ombulabs.com).

--- a/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
+++ b/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 4.2 to 5.0"
 date: 2018-03-06 10:53:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-06-22-announcing-audit-tool.markdown
+++ b/_posts/2018-06-22-announcing-audit-tool.markdown
@@ -4,6 +4,7 @@ title:  "Announcing Gemfile.lock Audit Tool"
 date: 2018-06-22 11:10:00
 categories: ["rails", "ruby", "rubygems"]
 author: "emily"
+canonical_url: true
 ---
 
 Today we are happy to announce the launch of our new microsite: [Gemfile.lock Audit Tool](https://audit.fastruby.io) - a tool created to allow users to check their Gemfile.lock for vulnerabilities in a quick and secure manner.

--- a/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
+++ b/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 5.0 to 5.1"
 date: 2018-07-18 10:05:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
+++ b/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
@@ -4,6 +4,7 @@ title: "Upgrade Rails from 5.1 to 5.2"
 date: 2018-08-14 12:42:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
+canonical_url: true
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-10-22-upgrading-a-rails-app.markdown
+++ b/_posts/2018-10-22-upgrading-a-rails-app.markdown
@@ -4,6 +4,7 @@ title:  "Upgrading a Rails Application from 2.3 to 4.2 with Neomind Labs"
 date: 2018-10-22 11:10:00
 categories: ["rails", "upgrades", "case-study"]
 author: "emily"
+canonical_url: true
 ---
 
 We recently spoke with Ryan Findley, Principal at [Neomind Labs](https://www.neomindlabs.com). We worked with his team to execute a **[Rails upgrade](https://fastruby.io) from 2.3 to 4.2** on one of their applications.

--- a/_posts/2018-11-14-writing-fast-rails-part-2.markdown
+++ b/_posts/2018-11-14-writing-fast-rails-part-2.markdown
@@ -4,6 +4,7 @@ title:  "Tips for Writing Fast Rails: Part 2"
 date: 2018-11-13 09:10:00
 categories: ["rails", "performance"]
 author: "luciano"
+canonical_url: true
 ---
 
 Some time ago we wrote a couple of [Tips for Writing Fast Rails](https://www.ombulabs.com/blog/performance/rails/writing-fast-rails.html). It was about time we wrote part two so here it is!


### PR DESCRIPTION
Hey @etagwerker @lubc 

This PR is adding the canonical url only to the posts will copy to Fast Ruby Blog. 

Here is an example: 

<img width="1280" alt="screen shot 2019-02-05 at 1 49 40 pm" src="https://user-images.githubusercontent.com/11785031/52285633-df794c80-294d-11e9-8e22-9a54de6b6004.png">

Please, take a look. Thanks.