### PR TITLE
Only run rspec when _not_ running in production

### DIFF
--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -21,7 +21,12 @@ Jekyll::Hooks.register :site, :post_write do |site|
     puts "Generated sitemap.xml.gz"
   end
 
-  puts "Running tests..."
-  system "bundle exec rspec spec/blog_spec.rb"
+  if ENV["RACK_ENV"] == "production"
+    puts "Skipping tests in production..."
+  else
+    puts "Running tests..."
+    system "bundle exec rspec spec/blog_spec.rb"
+  end
+
   puts "All done!"
 end


### PR DESCRIPTION
Hey @ercohen14, 

This PR fixes a problem we are having with automatic deployments on Heroku. (more here: https://www.pivotaltracker.com/story/show/166380542)

Please check it out.

Thanks! 