### PR TITLE
[#172315782] Redirect tutorial articles to fastruby.io

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,18 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-  {%- capture page_title -%}{%- if page.category -%}{{page.category | titleize}} at {{site.description}}{%- elsif page -%}{{ page.title | titleize}} - {{ site.description }}{%- else -%}{{ site.description }} - {{ page.title | titleize }}{%- endif -%}{%- endcapture -%}
+  {%- capture page_title -%}{%- if page.category -%}{{page.category | titleize}} at
+  {{site.description}}{%- elsif page -%}{{ page.title | titleize}} -
+  {{ site.description }}{%- else -%}{{ site.description }} - {{ page.title | titleize }}{%- endif -%}{%- endcapture -%}
 
   <title>{{ page_title }}</title>
 
-  {%- capture description -%}{%if page.meta.description -%}{{page.meta.description}}{%- elsif page.category -%}Articles about {{page.category | titleize}} in the {{site.description}}
+  {% if page.redirect %}
+  <meta http-equiv="refresh" content="0; url={{ page.redirect }}{{ page.url }}">
+  {% endif %}
+
+  {%- capture description -%}{%if page.meta.description -%}{{page.meta.description}}{%- elsif page.category -%}Articles
+  about {{page.category | titleize}} in the {{site.description}}
   blog.{%- elsif page -%}{{ page.excerpt | strip_html }}{%- else -%}{{ site.meta_description }}{%- endif -%}{%- endcapture -%}
   {%- capture social_description -%}{{ description | truncatewords: 50 }}{%- endcapture -%}
   {%- capture social_title -%}{%- if page -%}{{ page.title }}{% if page.author and site.authors[page.author].twitter %}
@@ -101,7 +108,7 @@
       ga.type = 'text/javascript';
       ga.async = true;
       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') +
-      '.google-analytics.com/ga.js';
+        '.google-analytics.com/ga.js';
       var s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(ga, s);
     })();

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
   {%- capture page_title -%}{%- if page.category -%}{{page.category | titleize}} at
-  {{site.description}}{%- elsif page -%}{{ page.title | titleize}} -
-  {{ site.description }}{%- else -%}{{ site.description }} - {{ page.title | titleize }}{%- endif -%}{%- endcapture -%}
+  {{site.description}}{%- elsif page -%}{{ page.title | titleize}} - {{ site.description }}{%- else -%}{{ site.description }} - {{ page.title | titleize }}{%- endif -%}{%- endcapture -%}
 
   <title>{{ page_title }}</title>
 
@@ -15,9 +14,7 @@
   <meta http-equiv="refresh" content="0; url={{ page.redirect }}{{ page.url }}">
   {% endif %}
 
-  {%- capture description -%}{%if page.meta.description -%}{{page.meta.description}}{%- elsif page.category -%}Articles
-  about {{page.category | titleize}} in the {{site.description}}
-  blog.{%- elsif page -%}{{ page.excerpt | strip_html }}{%- else -%}{{ site.meta_description }}{%- endif -%}{%- endcapture -%}
+  {%- capture description -%}{%if page.meta.description -%}{{page.meta.description}}{%- elsif page.category -%}Articles about {{page.category | titleize}} in the {{site.description}} blog.{%- elsif page -%}{{ page.excerpt | strip_html }}{%- else -%}{{ site.meta_description }}{%- endif -%}{%- endcapture -%}
   {%- capture social_description -%}{{ description | truncatewords: 50 }}{%- endcapture -%}
   {%- capture social_title -%}{%- if page -%}{{ page.title }}{% if page.author and site.authors[page.author].twitter %}
   by @{{ site.authors[page.author].twitter }}{% endif %}{%- else -%}{{ page_title }}{%- endif -%}{%- endcapture -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,8 +6,21 @@ post_class: post-template
 ---
 
 {% if page.canonical_url %}
-  <link rel="canonical" href="{{ site.fastruby_blog }}{{ page.url }}"/>
+<link rel="canonical" href="{{ site.fastruby_blog }}{{ page.url }}" />
 {% endif %}
+
+{% if page.redirect %}
+
+<main class="content post-layout" role="main">
+  <article class="post">
+    <header class="post-header">
+      <h1>Redirecting to FastRuby.io blog article</h1>
+      <p>If you are not redirected automatically, please click <a href="{{ page.redirect }}{{ page.url }}">here</a></p>
+    </header>
+  </article>
+</main>
+
+{% else %}
 
 <main class="content post-layout" role="main">
   <article class="post">
@@ -22,15 +35,16 @@ post_class: post-template
     <section class="post-content">
       {{ content }}
     </section>
-    
+
     {%- if page.archive -%}
     <section class="archive">
-        <h5>Archive</h5>
-        <ul>
-            {%- for post in site.posts -%}
-                <li><span>{{ post.date | date_to_string }}</span>  <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
-            {%- endfor -%}
-        </ul>
+      <h5>Archive</h5>
+      <ul>
+        {%- for post in site.posts -%}
+        <li><span>{{ post.date | date_to_string }}</span> <a
+            href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
+        {%- endfor -%}
+      </ul>
     </section>
     {%- endif -%}
     <div aria-label="Blog's tags">
@@ -38,23 +52,25 @@ post_class: post-template
     </div>
     <footer class="post-footer" aria-label="Author's information">
       {%- if page.author -%}
-        {%- assign author = site.authors[page.author] -%}
-        <figure class="author-image">
-          {%- if author.gravatar -%}
-            <a class="img" aria-label="Author's picture" href="{{ page.baseurl }}" style="background-image: url(//2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
-            <span class="hidden" aria-hidden="true">{{author.display_name}}'s Picture</span></a>
-          {%- else -%}
-            <a class="img" aria-label="Author's picture" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
-            <span class="hidden" aria-hidden="true"></span></a>
-          {%- endif -%}
-        </figure>
-        <section class="author">
-          <h4> {{ author.display_name }} </h4>
-          <p>
-            We are the Lean Software Boutique. Check us out at <a href="https://www.ombulabs.com">www.ombulabs.com</a>
-          </p>
-        </section>
-          
+      {%- assign author = site.authors[page.author] -%}
+      <figure class="author-image">
+        {%- if author.gravatar -%}
+        <a class="img" aria-label="Author's picture" href="{{ page.baseurl }}"
+          style="background-image: url(//2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
+          <span class="hidden" aria-hidden="true">{{author.display_name}}'s Picture</span></a>
+        {%- else -%}
+        <a class="img" aria-label="Author's picture" href="{{ page.baseurl }}"
+          style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
+          <span class="hidden" aria-hidden="true"></span></a>
+        {%- endif -%}
+      </figure>
+      <section class="author">
+        <h4> {{ author.display_name }} </h4>
+        <p>
+          We are the Lean Software Boutique. Check us out at <a href="https://www.ombulabs.com">www.ombulabs.com</a>
+        </p>
+      </section>
+
       {%- endif -%}
 
       <!-- Share links section -->
@@ -67,3 +83,5 @@ post_class: post-template
   </article>
   {%- include site_footer.html -%}
 </main>
+
+{% endif %}

--- a/_posts/2017-08-28-upgrade-to-rails-3.markdown
+++ b/_posts/2017-08-28-upgrade-to-rails-3.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "luciano"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 This article is the first of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org) application from [version 2.3](http://guides.rubyonrails.org/2_3_release_notes.html) to [3.0](http://guides.rubyonrails.org/3_0_release_notes.html).

--- a/_posts/2017-10-16-upgrade-to-rails-3-1.md
+++ b/_posts/2017-10-16-upgrade-to-rails-3-1.md
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "luciano"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 This is the second article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.0](http://guides.rubyonrails.org/3_0_release_notes.html) to [3.1](http://guides.rubyonrails.org/3_1_release_notes.html). If you are in an older version, you can take a look at our [previous article](https://www.ombulabs.com/blog/rails/upgrades/upgrade-to-rails-3.html).

--- a/_posts/2017-11-07-upgrade-to-rails-3-2.md
+++ b/_posts/2017-11-07-upgrade-to-rails-3-2.md
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "luciano"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 This is the third article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.1](http://guides.rubyonrails.org/3_1_release_notes.html) to [3.2](http://guides.rubyonrails.org/3_2_release_notes.html).

--- a/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
+++ b/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
+++ b/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
+++ b/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
+++ b/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
+++ b/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.

--- a/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
+++ b/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
@@ -6,6 +6,7 @@ reviewed: 2020-03-05 10:00:00
 categories: ["rails", "upgrades"]
 author: "mauro-oto"
 canonical_url: true
+redirect: https://www.fastruby.io/blog
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.


### PR DESCRIPTION
Pivotal Story Reference: https://www.pivotaltracker.com/story/show/172315782

This PR:
- Redirects those articles about Rails Upgrade to FastRuby.io.

To achieve this I've added a `redirect` variable into the from matter for those articles about Rails upgrades.
The variable: `redirect: https://www.fastruby.io/blog`
The articles:
_posts/2017-08-28-upgrade-to-rails-3.markdown
_posts/2017-10-16-upgrade-to-rails-3-1.md
 _posts/2017-11-07-upgrade-to-rails-3-2.md
 _posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
 _posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
 _posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
 _posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
 _posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown

And then I've added a conditional into `<head>` to automatically redirect if the post has the `redirect` variable:
` {% if page.redirect %}<meta http-equiv="refresh" content="0; url={{ page.redirect }}{{ page.url }}">{% endif %}`

Additionally, I've added a text for those articules that iwll be redirected into the `post` layout to notice the user that is beeing redirected:
`<main class="content post-layout" role="main">
  <article class="post">
    <header class="post-header">
      <h1>Redirecting to FastRuby.io blog article</h1>
      <p>If you are not redirected automatically, please click <a href="{{ page.redirect }}{{ page.url }}">here</a></p>
    </header>
  </article>
</main>`

@ABizzinotto Let me know if you want to change this content.