### PR TITLE
Change author position

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,19 +19,6 @@ post_class: post-template
       {{ content }}
     </section>
 
-    {%- if page.archive -%}
-    <section class="archive">
-        <h5>Archive</h5>
-        <ul>
-            {%- for post in site.posts -%}
-                <li><span>{{ post.date | date_to_string }}</span>  <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
-            {%- endfor -%}
-        </ul>
-    </section>
-    {%- endif -%}
-    <div aria-label="Blog's tags">
-      {%- include tag_list.html -%}
-    </div>
     <footer class="post-footer" aria-label="Author's information">
       {%- if page.author -%}
         {%- assign author = site.authors[page.author] -%}
@@ -60,6 +47,19 @@ post_class: post-template
       {%- include disqus.html -%}
 
     </footer>
+    {%- if page.archive -%}
+    <section class="archive">
+        <h5>Archive</h5>
+        <ul>
+            {%- for post in site.posts -%}
+                <li><span>{{ post.date | date_to_string }}</span>  <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
+            {%- endfor -%}
+        </ul>
+    </section>
+    {%- endif -%}
+    <div aria-label="Blog's tags">
+      {%- include tag_list.html -%}
+    </div>
   </article>
   {%- include site_footer.html -%}
 </main>


### PR DESCRIPTION
This PR makes changes to the position of the author after a blog post. It follows the same positioning as the fastruby.io blog. It addresses this story:
https://www.pivotaltracker.com/story/show/173340332

**Before:**
![Screen Shot 2020-06-17 at 10 24 51 AM](https://user-images.githubusercontent.com/28625558/84911277-f2457a80-b085-11ea-8108-d708b3a58920.png)
**After:**
![Screen Shot 2020-06-17 at 10 24 23 AM](https://user-images.githubusercontent.com/28625558/84911327-00939680-b086-11ea-8a9b-6ab4eafbd2dd.png)

![Screen Shot 2020-06-17 at 10 24 33 AM](https://user-images.githubusercontent.com/28625558/84911484-359fe900-b086-11ea-91c7-88bc9614efdf.png)


