### PR TITLE
Remove hidden from button from search submit to fix problem in  Safari. 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,7 +73,7 @@
       <form action='/search' method='GET'>
         <div id='search-input-wrapper'>
           <input type="search" name="query" size="30" aria-label="Search blog posts" placeholder="Search blog posts..." required id="search-input"/>
-          <button type='submit' hidden></button>
+          <button type='submit'></button>
           <button class='close icon-cross'></button>
         </div>
         <button id="search-button" class='search-button'><i class="icon-search"></i></button>


### PR DESCRIPTION
This PR removes the hidden attribute from submit button for the Search bar. This addresses the problem of it not working in Safari.

What is this PR:

 Bug fix

https://www.pivotaltracker.com/story/show/174300650

This works with this ombulabs.com: https://github.com/ombulabs/ombulabs.com/pull/207

This is currently deployed in staging(8/12)

How has this been tested?

 Automated tests
 Manual tests
What manual tests have been run?

Looked at this in staging because I was not able to reproduce locally.

What browsers did you test it on (if applicable)?

 Chrome
 Safari