### PR TITLE
Change Freckle to Noko in blog post

### DIFF
--- a/_posts/2016-06-06-introducing-pecas.markdown
+++ b/_posts/2016-06-06-introducing-pecas.markdown
@@ -7,14 +7,14 @@ categories: ["open-source"]
 author: "etagwerker"
 ---
 
-At [Ombu Labs](https://www.ombulabs.com) we are big fans and happy customers
+At [OmbuLabs](https://www.ombulabs.com) we are big fans and happy customers
 of [Noko](https://nokotime.com/). We use their widget to track all the
 hours that we spend on client projects,
 [open source](https://www.ombulabs.com/#open-source) development, and
 [our own products](https://www.ombulabs.com/#products).
 
-Today I'm happy to introduce [Pecas, time tracking leaderboards for Noko](http://ombulabs.github.io/pecas/)! **Pecas** is an
-[open source](http://github.com/ombulabs/pecas) tool that integrates with your
+Today I'm happy to introduce [Pecas, time tracking leaderboards for Noko](http://fastruby.github.io/pecas/)! **Pecas** is an
+[open source](http://github.com/fastruby/pecas) tool that integrates with your
 account and generates beautiful leaderboards per project and per teammate.
 
 Here is a sample dashboard for all your projects:
@@ -33,7 +33,7 @@ good way to detect deviations.
 To build this small application we decided to use
 [Rails 4.2](http://rubyonrails.org/) and the
 [Noko API v2](https://developer.nokotime.com/). You can easily
-set it up using [Heroku](http://heroku.com) and your Noko API key: [https://github.com/ombulabs/pecas#first-time-only](https://github.com/ombulabs/pecas#first-time-only)
+set it up using [Heroku](http://heroku.com) and your Noko API key: [https://github.com/ombulabs/pecas#first-time-only](https://github.com/fastruby/pecas#first-time-only)
 
 If you like [Noko](https://nokotime.com/) as much as we do, feel free to
-**fork Pecas** in [Github](https://github.com/ombulabs): [https://github.com/ombulabs/pecas](https://github.com/ombulabs/pecas)
+**fork Pecas** in [Github](https://github.com/fastruby): [https://github.com/fastruby/pecas](https://github.com/fastruby/pecas)

--- a/_posts/2016-06-06-introducing-pecas.markdown
+++ b/_posts/2016-06-06-introducing-pecas.markdown
@@ -1,19 +1,19 @@
 ---
 layout: post
-title: "Introducing Pecas: Dashboards for Freckle"
+title: "Introducing Pecas: Dashboards for Noko"
 date: 2016-06-06 9:31:00
-reviewed: 2020-03-05 10:00:00
+reviewed: 2020-09-15 10:00:00
 categories: ["open-source"]
 author: "etagwerker"
 ---
 
 At [Ombu Labs](https://www.ombulabs.com) we are big fans and happy customers
-of [Freckle](https://letsfreckle.com/). We use their widget to track all the
+of [Noko](https://nokotime.com/). We use their widget to track all the
 hours that we spend on client projects,
 [open source](https://www.ombulabs.com/#open-source) development, and
 [our own products](https://www.ombulabs.com/#products).
 
-Today I'm happy to introduce [Pecas, time tracking leaderboards for Freckle](http://ombulabs.github.io/pecas/)! **Pecas** is an
+Today I'm happy to introduce [Pecas, time tracking leaderboards for Noko](http://ombulabs.github.io/pecas/)! **Pecas** is an
 [open source](http://github.com/ombulabs/pecas) tool that integrates with your
 account and generates beautiful leaderboards per project and per teammate.
 
@@ -32,8 +32,8 @@ good way to detect deviations.
 
 To build this small application we decided to use
 [Rails 4.2](http://rubyonrails.org/) and the
-[Freckle API v2](http://developer.letsfreckle.com/#overview). You can easily
-set it up using [Heroku](http://heroku.com) and your Freckle API key: [https://github.com/ombulabs/pecas#first-time-only](https://github.com/ombulabs/pecas#first-time-only)
+[Noko API v2](https://developer.nokotime.com/). You can easily
+set it up using [Heroku](http://heroku.com) and your Noko API key: [https://github.com/ombulabs/pecas#first-time-only](https://github.com/ombulabs/pecas#first-time-only)
 
-If you like [Freckle](https://letsfreckle.com) as much as we do, feel free to
+If you like [Noko](https://nokotime.com/) as much as we do, feel free to
 **fork Pecas** in [Github](https://github.com/ombulabs): [https://github.com/ombulabs/pecas](https://github.com/ombulabs/pecas)


### PR DESCRIPTION
This PR updates the blog post on Pecas so that Freckle is now exchanged for Noko. 
https://www.pivotaltracker.com/story/show/173803668